### PR TITLE
Fix failure on cygwin (unnecessary 'cygpath -w' caused an issue)

### DIFF
--- a/bin/pdfjam
+++ b/bin/pdfjam
@@ -932,11 +932,7 @@ do
 	    sourceFullPath="$sourceDir"/"$pdfName"
 	    uniqueName="source-$counter.pdf"
 	    uniqueName="$PDFJAM_TEMP_DIR"/"$uniqueName"
-	    ## Next is from the Cygwin patch contributed by Lucas
-	    case $(uname) in
-		*CYGWIN*) cp "$sourceFullPath" "$uniqueName";;
-		*) ln -s "$sourceFullPath" "$uniqueName";;
-            esac
+	    ln -s "$sourceFullPath" "$uniqueName"
 	    ;;
     esac
     filePageList="$filePageList","$uniqueName","$pageSpec"
@@ -986,10 +982,6 @@ fileName="$PDFJAM_TEMP_DIR"/a
 texFile="$fileName".tex
 msgFile="$fileName".msgs
 tempFile="$PDFJAM_TEMP_DIR"/temp.tex
-## Next is adapted from the Cygwin patch sent by Lucas
-case $(uname) in
-    *CYGWIN*) filePageList=$(echo "$filePageList" | sed 's~\\~/~g') ;;
-esac
 (cat <<EndTemplate
 \batchmode
 \documentclass[$documentOptions]{article}

--- a/bin/pdfjam
+++ b/bin/pdfjam
@@ -808,10 +808,6 @@ else
     (umask 077 && mkdir "$PDFJAM_TEMP_DIR")
 fi
 umask "$original_umask"
-## Next is from the Cygwin patch contributed by Lucas
-case $(uname) in
-    *CYGWIN*) PDFJAM_TEMP_DIR=$(cygpath -w "$PDFJAM_TEMP_DIR");;
-esac
 ##
 ##  TEMPORARY DIRECTORY ALL DONE
 ##


### PR DESCRIPTION
This will fix the issue #20 by removing unnecessary `cygpath -w`.