### PR TITLE
Improve codes for pdfinfo stuff and remove dependency on hyperref.sty

### DIFF
--- a/bin/pdfjam
+++ b/bin/pdfjam
@@ -502,6 +502,10 @@ while test -n "${1}${2}"; do
 		    --preamble)
 			preamble="$preamble${2}" ;
 			shift ;;
+		    --enc) # command line encoding
+			enc="${2}"
+			callOptions="$callOptions ${1} ${2}"
+			shift ;;
 		    --*)
                         ##  options for \includepdfmerge
 			argName=$(printf "%s" "${1}" | sed 's/^--//');
@@ -697,23 +701,6 @@ then
     error_exit \
 	"LaTeX package everyshi.sty not installed (see the pdfpages manual)" \
 	$E_UNAVAILABLE
-    if test "$keepinfo" = true ||
-	test -n "$pdfTitle$pdfSubject$pdfAuthor$pdfKeywords"
-    ##  ie, if hyperref is required
-    then
-	(kpsewhich hyperref.sty >/dev/null) || {
-	    prattle "LaTeX package hyperref.sty is not installed, so any"
-	    prattle "--keepinfo, --pdftitle,--pdfauthor, --pdfsubject or" 1
-	    prattle "--pdfkeywords setting will be ignored." 1
-	    hyperref=false
-	    if test "$batch" = true
-	    then
-		export hyperref   ## for use in any secondary calls
-	    fi
-	}
-    else
-	hyperref=false
-    fi
     if test "$geometry" = true
     ##  ie, if the 'geometry' package is needed for paper size
     then
@@ -728,37 +715,31 @@ then
 	}
     fi
 fi
-if test "$hyperref" = false
+if  test "$keepinfo" = true
 then
-    keepinfo=false
-    pdfTitle="" ; pdfAuthor="" ; pdfSubject="" ; pdfKeywords=""
-else
-    if  test "$keepinfo" = true
-    then
-	case "$pdfinfo" in
-	    "not found")
-		if test $PDFJAM_CALL_NUMBER -eq 0
-		then
-		  prattle \
-		  "The pdfinfo utility was not found, so --keepinfo is ignored."
-		fi
-		keepinfo=false
-		;;
-	    pdfinfo)
-		;;
-	    *)  ## $pdfinfo was set in a configuration file
-		if test ! -x "$pdfinfo"
-		then
-		    if test $PDFJAM_CALL_NUMBER -eq 0
-		    then
-			prattle \
-		     "No pdfinfo utility at $pdfinfo, so --keepinfo is ignored."
-			keepinfo=false
-		    fi
-		fi
-		;;
-	esac
-    fi
+    case "$pdfinfo" in
+	"not found")
+	  if test $PDFJAM_CALL_NUMBER -eq 0
+	  then
+	    prattle \
+	      "The pdfinfo utility was not found, so --keepinfo is ignored."
+	  fi
+	  keepinfo=false
+	  ;;
+	pdfinfo)
+	  ;;
+	*)  ## $pdfinfo was set in a configuration file
+	  if test ! -x "$pdfinfo"
+	  then
+	    if test $PDFJAM_CALL_NUMBER -eq 0
+	    then
+	      prattle \
+		"No pdfinfo utility at $pdfinfo, so --keepinfo is ignored."
+	      keepinfo=false
+	    fi
+	  fi
+	  ;;
+    esac
 fi
 ## A function to check if using non-Cygwin "${latex}" from Cygwin
 using_non_cygwin_latex_from_cygwin () {
@@ -964,38 +945,55 @@ filePageList=$(printf "%s" "$filePageList" | \
 ##
 ##  Do the pdfinfo stuff (if relevant)...
 ##
-if  test "$hyperref" != false
-then
-    if test "$keepinfo" = true
-    then
-	prattle "Calling ${pdfinfo}..."  ;
-	PDFinfo=$(pdfinfo "$uniqueName");
-	pdftitl=$(printf "%s" "$PDFinfo" | \
-	    grep -e '^Title:'| 'sed s/^Title:\\\s\*//' | \
-	    sed -e 's/[#$%^&_{}~]/\\\&/g');
-	pdfauth=$(printf "%s" "$PDFinfo" | \
-	    grep -e '^Author:'| sed 's/^Author:\\\s\*//' | \
-	    sed -e 's/[#$%^&_{}~]/\\\&/g');
-	pdfsubj=$(printf "%s" "$PDFinfo" | \
-	    grep -e '^Subject:'| sed 's/^Subject:\\\s\*//' | \
-	    sed -e 's/[#$%^&_{}~]/\\\&/g');
-	pdfkeyw=$(printf "%s" "$PDFinfo" | \
-	    grep -e '^Keywords:'| sed 's/^Keywords:\\\s\*//' | \
-	    sed -e 's/[#$%^&_{}~]/\\\&/g');
+select_pdfinfo () {
+    printf '%s' "$2" | \
+    grep -e "^$1:" | \
+    sed -e 's/^'"$1"':\s*//'
+}
+echo_hex_iconv_utf16be () {
+    printf '%s' "$1" | \
+    iconv -f utf8 -t utf16be | \
+    od -An -v -tx1 | \
+    tr -d '[:space:]'
+}
+echo_pdfinfodata () {
+    if [ -n "$2" ]; then
+	TMPA=$(echo_hex_iconv_utf16be "$2")
+	printf '%s' "/$1 <feff${TMPA}>"
     fi
-    if test -n "$pdfTitle" ; then
-	pdftitl="$pdfTitle"
-    fi
-    if test -n "$pdfAuthor" ; then
-	pdfauth="$pdfAuthor"
-    fi
-    if test -n "$pdfSubject" ; then
-	pdfsubj="$pdfSubject"
-    fi
-    if test -n "$pdfKeywords" ; then
-	pdfkeyw="$pdfKeywords"
-    fi
+}
+
+if test "$keepinfo" = true ; then
+    prattle "Calling ${pdfinfo}..."
+    PDFinfo=$(pdfinfo -enc UTF-8 "$uniqueName")
+    pdftitl=$(select_pdfinfo 'Title'    "$PDFinfo")
+    pdfauth=$(select_pdfinfo 'Author'   "$PDFinfo")
+    pdfsubj=$(select_pdfinfo 'Subject'  "$PDFinfo")
+    pdfkeyw=$(select_pdfinfo 'Keywords' "$PDFinfo")
 fi
+echo_iconv_from_enc () {
+    printf '%s' "$2" | \
+    iconv -f "$1" -t utf8
+}
+if test -n "$pdfTitle" ; then
+    pdftitl=$(echo_iconv_from_enc "$enc" "$pdfTitle")
+fi
+if test -n "$pdfAuthor" ; then
+    pdfauth=$(echo_iconv_from_enc "$enc" "$pdfAuthor")
+fi
+if test -n "$pdfSubject" ; then
+    pdfsubj=$(echo_iconv_from_enc "$enc" "$pdfSubject")
+fi
+if test -n "$pdfKeywords" ; then
+    pdfkeyw=$(echo_iconv_from_enc "$enc" "$pdfKeywords")
+fi
+
+## Converting to PDF string
+raw_pdftitl=$(echo_pdfinfodata 'Title'    "$pdftitl")
+raw_pdfauth=$(echo_pdfinfodata 'Author'   "$pdfauth")
+raw_pdfsubj=$(echo_pdfinfodata 'Subject'  "$pdfsubj")
+raw_pdfkeyw=$(echo_pdfinfodata 'Keywords' "$pdfkeyw")
+
 ##
 ##  Now set up the files for latex...
 ##
@@ -1013,20 +1011,23 @@ fi
 \usepackage{color} \definecolor{bgclr}{RGB}{$pagecolor} \pagecolor{bgclr}
 \usepackage[$papersize]{geometry}
 \usepackage[utf8]{inputenc}
-\usepackage{hyperref}
-\hypersetup{pdftitle={$pdftitl}}
-\hypersetup{pdfauthor={$pdfauth}}
-\hypersetup{pdfsubject={$pdfsubj}}
-\hypersetup{pdfkeywords={$pdfkeyw}}
+\ifdefined\luatexversion% LuaLaTeX
+  \protected\def\pdfinfo{\pdfextension info}
+\fi
+\ifdefined\XeTeXversion% XeLaTeX
+  \protected\def\pdfinfo#1{\AtBeginDvi{\special{pdf:docinfo << #1 >>}}}
+\fi
+\ifdefined\pdfinfo%
+  \pdfinfo{%
+    $raw_pdftitl %
+    $raw_pdfauth %
+    $raw_pdfsubj %
+    $raw_pdfkeyw %
+  }%
+\fi
 \usepackage{pdfpages}
 EndTemplate
     )  > "$texFile"
-if test "$hyperref" = false; then  ## we don't need hyperref
-    cp "$texFile" "$tempFile"
-    sed '/\\\usepackage{hyperref}/d' "$tempFile" | \
-	sed '/\\\hypersetup.*/d' > "${texFile}"
-    rm "$tempFile"
-fi
 if test -z "$geometry" ; then geometry=false ; fi
 if test "$geometry" = false; then   ## geometry package is not to be used
     cp "$texFile" "$tempFile"

--- a/bin/pdfjam
+++ b/bin/pdfjam
@@ -760,6 +760,11 @@ else
 	esac
     fi
 fi
+## A function to check if using non-Cygwin "${latex}" from Cygwin
+using_non_cygwin_latex_from_cygwin () {
+  [ x"$(uname -o)" = x"Cygwin" ] \
+  && "${latex}" -version | head -1 | grep -qv Cygwin
+}
 ##
 ##  END OF CHECKING THE SETUP
 ##
@@ -809,9 +814,9 @@ else
 fi
 umask "$original_umask"
 ## Next is from the Cygwin patch contributed by Lucas
-case $(uname) in
-    *CYGWIN*) PDFJAM_TEMP_DIR=$(cygpath -w "$PDFJAM_TEMP_DIR");;
-esac
+if using_non_cygwin_latex_from_cygwin; then
+    PDFJAM_TEMP_DIR=$(cygpath -w "$PDFJAM_TEMP_DIR")
+fi
 ##
 ##  TEMPORARY DIRECTORY ALL DONE
 ##
@@ -937,10 +942,11 @@ do
 	    uniqueName="source-$counter.pdf"
 	    uniqueName="$PDFJAM_TEMP_DIR"/"$uniqueName"
 	    ## Next is from the Cygwin patch contributed by Lucas
-	    case $(uname) in
-		*CYGWIN*) cp "$sourceFullPath" "$uniqueName";;
-		*) ln -s "$sourceFullPath" "$uniqueName";;
-            esac
+	    if using_non_cygwin_latex_from_cygwin; then
+		cp "$sourceFullPath" "$uniqueName"
+	    else
+		ln -s "$sourceFullPath" "$uniqueName"
+	    fi
 	    ;;
     esac
     filePageList="$filePageList","$uniqueName","$pageSpec"
@@ -991,9 +997,9 @@ texFile="$fileName".tex
 msgFile="$fileName".msgs
 tempFile="$PDFJAM_TEMP_DIR"/temp.tex
 ## Next is adapted from the Cygwin patch sent by Lucas
-case $(uname) in
-    *CYGWIN*) filePageList=$(echo "$filePageList" | sed 's~\\~/~g') ;;
-esac
+if using_non_cygwin_latex_from_cygwin; then
+    filePageList=$(echo "$filePageList" | sed 's~\\~/~g')
+fi
 (cat <<EndTemplate
 \batchmode
 \documentclass[$documentOptions]{article}

--- a/bin/pdfjam
+++ b/bin/pdfjam
@@ -664,7 +664,7 @@ documentOptions=$(printf "%s" "$documentOptions" | sed 's/^,//' | sed 's/,$//')
 if test $PDFJAM_CALL_NUMBER -eq 0  ## not a secondary call
 then
     ##  Check whether there's a suitable latex to use:
-    case $latex in
+    case "$latex" in
 	"not found")
 	    error_exit "can't find pdflatex!" $E_UNAVAILABLE
 	    ;;
@@ -735,7 +735,7 @@ then
 else
     if  test "$keepinfo" = true
     then
-	case $pdfinfo in
+	case "$pdfinfo" in
 	    "not found")
 		if test $PDFJAM_CALL_NUMBER -eq 0
 		then
@@ -1059,7 +1059,7 @@ log file at
 to try to diagnose the problem."
 i=1
 while [ "$i" -le "$runs" ] ; do
-    $latex "$texFile" > "$msgFile" || {
+    "$latex" "$texFile" > "$msgFile" || {
         prattle "$failureText"
         error_exit "Run $i: Output file not written" $E_SOFTWARE
     }

--- a/bin/pdfjam
+++ b/bin/pdfjam
@@ -762,8 +762,15 @@ else
 fi
 ## A function to check if using non-Cygwin "${latex}" from Cygwin
 using_non_cygwin_latex_from_cygwin () {
-  [ x"$(uname -o)" = x"Cygwin" ] \
-  && "${latex}" -version | head -1 | grep -qv Cygwin
+    if [ -z "${__cache__using_non_cygwin_latex_from_cygwin}" ]; then
+	if [ x"$(uname -o)" = x"Cygwin" ] \
+	    && "${latex}" -version | head -1 | grep -qv Cygwin; then
+	    __cache__using_non_cygwin_latex_from_cygwin=0
+	else
+	    __cache__using_non_cygwin_latex_from_cygwin=1
+	fi
+    fi
+    return "${__cache__using_non_cygwin_latex_from_cygwin}"
 }
 ##
 ##  END OF CHECKING THE SETUP

--- a/pdfjam-help.txt
+++ b/pdfjam-help.txt
@@ -146,6 +146,9 @@ where
      --vanilla
                   Suppress the reading of any site-wide or user-specific
                   configuration files.
+     --enc
+                  Specify a command-line encoding
+                  [Default for you at this site: enc=$enc]
      --KEY VALUE
                   Specify options to '\includepdfmerge', in the LaTeX
                   'pdfpages' package.  Here KEY is the name of any of the

--- a/pdfjam.conf
+++ b/pdfjam.conf
@@ -95,5 +95,8 @@ twoside='false'     ## overridden by '--twoside' in the call
 ##
 preamble=''         ## concatenate other strings to this by using '--preamble'
 ##
+# enc='utf8'        ## overridden by '--enc ENC' in the call
+#                   ## ENC must be one of iconv encodings
+##
 ###############################################################
 ##  END OF FILE: that's all you can configure here!


### PR DESCRIPTION
PDFinfo strings have been able to contain backslash and non-ascii characters.

Dependency on `hyperref.sty` have been removed, instead of a new dependecy on `iconv` to encode PDFinfo strings.


This includes PR #22.
An essential commit here is 47b997bfac83a81403bc8d3e922e1aca98fcaab0

